### PR TITLE
feat: Answer 저장 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+	testImplementation 'io.findify:s3mock_2.12:0.2.4'
     testImplementation 'org.projectlombok:lombok:1.18.22'
     compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
     testImplementation 'org.projectlombok:lombok:1.18.22'
     compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/b4after/bntquestion/BntQuestionApplication.java
+++ b/src/main/java/com/b4after/bntquestion/BntQuestionApplication.java
@@ -6,6 +6,10 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class BntQuestionApplication {
 
+	static {
+		System.setProperty("com.amazonaws.sdk.disableEc2Metadata", "true");
+	}
+
 	public static void main(String[] args) {
 		SpringApplication.run(BntQuestionApplication.class, args);
 	}

--- a/src/main/java/com/b4after/bntquestion/WebConfig.java
+++ b/src/main/java/com/b4after/bntquestion/WebConfig.java
@@ -1,0 +1,16 @@
+package com.b4after.bntquestion;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedMethods("*")
+                .allowedOrigins("*");
+    }
+}

--- a/src/main/java/com/b4after/bntquestion/controller/AnswerController.java
+++ b/src/main/java/com/b4after/bntquestion/controller/AnswerController.java
@@ -1,0 +1,25 @@
+package com.b4after.bntquestion.controller;
+
+import com.b4after.bntquestion.dto.AnswerCreateRequest;
+import com.b4after.bntquestion.service.AnswerService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+@RestController
+@RequiredArgsConstructor
+public class AnswerController {
+
+    private final AnswerService answerService;
+
+    @PostMapping("/answers")
+    public ResponseEntity<Void> registerAnswer(@ModelAttribute AnswerCreateRequest request) {
+        Long answerId = answerService.createAnswer(request);
+        return ResponseEntity.created(URI.create("/answers/" + answerId))
+                .build();
+    }
+}

--- a/src/main/java/com/b4after/bntquestion/domain/Answer.java
+++ b/src/main/java/com/b4after/bntquestion/domain/Answer.java
@@ -16,22 +16,32 @@ public class Answer {
     @Column(name = "answer_id")
     private Long id;
 
+    @Column(nullable = false)
     private Long questionId;
 
+    @Column(nullable = false)
     private Long memberId;
 
     @Enumerated(EnumType.STRING)
-    @Column(length = 8)
+    @Column(length = 8, nullable = false)
     private AnswerStatus answerStatus;
 
-    @Column(length = 64)
-    private String audioFileObjectKey;
+    @Embedded
+    private AnswerAudio answerAudio;
 
-    public Answer(Long questionId, Long memberId, String audioFileObjectKey, AnswerStatus answerStatus) {
+    public static Answer createBeforeGrading(Long questionId, Long memberId, AnswerAudio answerAudio) {
+        return new Answer(questionId, memberId, answerAudio, AnswerStatus.BEFORE);
+    }
+
+    private Answer(Long questionId, Long memberId, AnswerAudio answerAudio, AnswerStatus answerStatus) {
         this.questionId = questionId;
         this.memberId = memberId;
         this.answerStatus = answerStatus;
-        this.audioFileObjectKey = audioFileObjectKey;
+        this.answerAudio = answerAudio;
+    }
+
+    public Answer(Long questionId, Long memberId, String audioFileObjectKey, AnswerStatus answerStatus) {
+        this(questionId, memberId, new AnswerAudio(audioFileObjectKey), answerStatus);
     }
 
     public boolean isGraded() {

--- a/src/main/java/com/b4after/bntquestion/domain/Answer.java
+++ b/src/main/java/com/b4after/bntquestion/domain/Answer.java
@@ -7,7 +7,10 @@ import lombok.NoArgsConstructor;
 import javax.persistence.*;
 
 @Entity
-@Table(indexes = @Index(name = "idx_member", columnList = "memberId"))
+@Table(
+        indexes = @Index(name = "idx_member", columnList = "memberId"),
+        uniqueConstraints = {@UniqueConstraint(name = "unique_column_in_answer", columnNames = "audioFileObjectKey")}
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Answer {

--- a/src/main/java/com/b4after/bntquestion/domain/Answer.java
+++ b/src/main/java/com/b4after/bntquestion/domain/Answer.java
@@ -21,19 +21,17 @@ public class Answer {
     private Long memberId;
 
     @Enumerated(EnumType.STRING)
+    @Column(length = 8)
     private AnswerStatus answerStatus;
 
-    private String audioUrl;
+    @Column(length = 64)
+    private String audioFileObjectKey;
 
-    public Answer(Long questionId, Long memberId, String audioUrl) {
-        this(questionId, memberId, audioUrl, AnswerStatus.BEFORE);
-    }
-
-    public Answer(Long questionId, Long memberId, String audioUrl, AnswerStatus answerStatus) {
+    public Answer(Long questionId, Long memberId, String audioFileObjectKey, AnswerStatus answerStatus) {
         this.questionId = questionId;
         this.memberId = memberId;
         this.answerStatus = answerStatus;
-        this.audioUrl = audioUrl;
+        this.audioFileObjectKey = audioFileObjectKey;
     }
 
     public boolean isGraded() {

--- a/src/main/java/com/b4after/bntquestion/domain/Answer.java
+++ b/src/main/java/com/b4after/bntquestion/domain/Answer.java
@@ -23,7 +23,7 @@ public class Answer {
     private Long memberId;
 
     @Enumerated(EnumType.STRING)
-    @Column(length = 8, nullable = false)
+    @Column(length = 10, nullable = false)
     private AnswerStatus answerStatus;
 
     @Embedded

--- a/src/main/java/com/b4after/bntquestion/domain/AnswerAudio.java
+++ b/src/main/java/com/b4after/bntquestion/domain/AnswerAudio.java
@@ -1,0 +1,19 @@
+package com.b4after.bntquestion.domain;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class AnswerAudio {
+
+    @Column(length = 64, nullable = false)
+    private String audioFileObjectKey;
+}

--- a/src/main/java/com/b4after/bntquestion/dto/AnswerCreateRequest.java
+++ b/src/main/java/com/b4after/bntquestion/dto/AnswerCreateRequest.java
@@ -1,0 +1,16 @@
+package com.b4after.bntquestion.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+@NoArgsConstructor
+@Getter
+@Setter
+public class AnswerCreateRequest {
+
+    private Long memberId;
+    private Long questionId;
+    private MultipartFile audio;
+}

--- a/src/main/java/com/b4after/bntquestion/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/b4after/bntquestion/exception/GlobalExceptionHandler.java
@@ -15,6 +15,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<String> handleUnexpectException(Exception exception) {
+        exception.printStackTrace();
         return ResponseEntity.internalServerError()
                 .body("예상하지 못한 서버 에러 발생");
     }

--- a/src/main/java/com/b4after/bntquestion/infrastructure/S3AnswerAudioUploader.java
+++ b/src/main/java/com/b4after/bntquestion/infrastructure/S3AnswerAudioUploader.java
@@ -1,0 +1,54 @@
+package com.b4after.bntquestion.infrastructure;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.b4after.bntquestion.domain.AnswerAudio;
+import com.b4after.bntquestion.service.AnswerAudioUploader;
+import com.b4after.bntquestion.utils.FileUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class S3AnswerAudioUploader implements AnswerAudioUploader {
+
+    private final AmazonS3Client amazonS3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Override
+    public AnswerAudio upload(MultipartFile audioFile) {
+        ObjectMetadata objectMetadata = setUpMetadata(audioFile);
+        return upload(audioFile, objectMetadata);
+    }
+
+    private ObjectMetadata setUpMetadata(MultipartFile audioFile) {
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentType(audioFile.getContentType());
+        objectMetadata.setContentLength(audioFile.getSize());
+        return objectMetadata;
+    }
+
+    private AnswerAudio upload(MultipartFile audioFile, ObjectMetadata objectMetadata) {
+        String audioFileObjectKey = createFileObjectKey(audioFile);
+        try (InputStream inputStream = audioFile.getInputStream()) {
+            PutObjectRequest request = new PutObjectRequest(bucket, audioFileObjectKey, inputStream, objectMetadata);
+            amazonS3Client.putObject(request);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("오디오 파일에서 문제가 발생했습니다.");
+        }
+        return new AnswerAudio(audioFileObjectKey);
+    }
+
+    private String createFileObjectKey(MultipartFile audioFile) {
+        return UUID.randomUUID() + "." + FileUtils.extractExtension(audioFile);
+    }
+}

--- a/src/main/java/com/b4after/bntquestion/service/AnswerAudioUploader.java
+++ b/src/main/java/com/b4after/bntquestion/service/AnswerAudioUploader.java
@@ -1,0 +1,9 @@
+package com.b4after.bntquestion.service;
+
+import com.b4after.bntquestion.domain.AnswerAudio;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface AnswerAudioUploader {
+
+    AnswerAudio upload(MultipartFile audioFile);
+}

--- a/src/main/java/com/b4after/bntquestion/service/AnswerService.java
+++ b/src/main/java/com/b4after/bntquestion/service/AnswerService.java
@@ -1,6 +1,9 @@
 package com.b4after.bntquestion.service;
 
 
+import com.b4after.bntquestion.domain.Answer;
+import com.b4after.bntquestion.domain.AnswerAudio;
+import com.b4after.bntquestion.dto.AnswerCreateRequest;
 import com.b4after.bntquestion.repository.AnswerRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,10 +14,15 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class AnswerService {
+
     private final AnswerRepository answerRepository;
+    private final AnswerAudioUploader answerAudioUploader;
 
     @Transactional
-    public void createAnswer(Long questionId, Long memberId, String audio) {
-        // todo
+    public Long createAnswer(AnswerCreateRequest request) {
+        AnswerAudio answerAudio = answerAudioUploader.upload(request.getAudio());
+        Answer answer = Answer.createBeforeGrading(request.getQuestionId(), request.getMemberId(), answerAudio);
+        answerRepository.save(answer);
+        return answer.getId();
     }
 }

--- a/src/main/java/com/b4after/bntquestion/utils/FileUtils.java
+++ b/src/main/java/com/b4after/bntquestion/utils/FileUtils.java
@@ -1,0 +1,22 @@
+package com.b4after.bntquestion.utils;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class FileUtils {
+
+    public static String extractExtension(MultipartFile file) {
+        String originalFilename = file.getOriginalFilename();
+        validateFileNull(originalFilename);
+        int index = originalFilename.lastIndexOf(".");
+        return originalFilename.substring(index + 1);
+    }
+
+    private static void validateFileNull(String originalFilename) {
+        if (originalFilename == null) {
+            throw new IllegalArgumentException("사용할 수 없는 파일 입니다.");
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,17 @@ spring:
     active: local
   jpa:
     open-in-view: false
+cloud:
+  aws:
+    region:
+      static: ap-northeast-2
+    s3:
+      bucket: k-bnt-15-files
+    credentials:
+      access-key: ${S3-ACCESS-KEY}
+      secret-key: ${S3-SECRET-KEY}
+    stack:
+      auto: false
 
 ---
 spring:
@@ -20,6 +31,7 @@ spring:
         hbm2ddl:
           auto:
             auto: create
+
 logging:
   level:
     org:

--- a/src/test/java/com/b4after/bntquestion/BntQuestionApplicationTests.java
+++ b/src/test/java/com/b4after/bntquestion/BntQuestionApplicationTests.java
@@ -1,10 +1,15 @@
 package com.b4after.bntquestion;
 
+import com.b4after.bntquestion.service.AnswerAudioUploader;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 @SpringBootTest
 class BntQuestionApplicationTests {
+
+	@MockBean
+	private AnswerAudioUploader answerAudioUploader;
 
 	@Test
 	void contextLoads() {

--- a/src/test/java/com/b4after/bntquestion/MockS3Config.java
+++ b/src/test/java/com/b4after/bntquestion/MockS3Config.java
@@ -1,0 +1,34 @@
+package com.b4after.bntquestion;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.AnonymousAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import io.findify.s3mock.S3Mock;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+@TestConfiguration
+public class MockS3Config {
+
+    @Bean
+    public S3Mock s3Mock() {
+        return new S3Mock.Builder().withPort(8001).withInMemoryBackend().build();
+    }
+
+    @Primary
+    @Bean(destroyMethod = "shutdown")
+    public AmazonS3 amazonS3(){
+        AwsClientBuilder.EndpointConfiguration endpoint = new AwsClientBuilder
+                .EndpointConfiguration("http://localhost:8081", Regions.AP_NORTHEAST_2.name());
+        return AmazonS3ClientBuilder
+                .standard()
+                .withPathStyleAccessEnabled(true)
+                .withEndpointConfiguration(endpoint)
+                .withCredentials(new AWSStaticCredentialsProvider(new AnonymousAWSCredentials()))
+                .build();
+    }
+}

--- a/src/test/java/com/b4after/bntquestion/acceptance/AcceptanceTest.java
+++ b/src/test/java/com/b4after/bntquestion/acceptance/AcceptanceTest.java
@@ -9,6 +9,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.context.jdbc.Sql;
 
+import java.util.UUID;
+
 import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.given;
 
@@ -28,8 +30,8 @@ class AcceptanceTest {
     @BeforeEach
     void setUp() {
         RestAssured.port = port;
-
+        String objectKey = UUID.randomUUID().toString();
         given(answerAudioUploader.upload(any()))
-                .willReturn(new AnswerAudio("mock-audio-file-object-key"));
+                .willReturn(new AnswerAudio(objectKey));
     }
 }

--- a/src/test/java/com/b4after/bntquestion/acceptance/AcceptanceTest.java
+++ b/src/test/java/com/b4after/bntquestion/acceptance/AcceptanceTest.java
@@ -4,13 +4,13 @@ import com.b4after.bntquestion.domain.AnswerAudio;
 import com.b4after.bntquestion.service.AnswerAudioUploader;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
-import org.mockito.BDDMockito;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.context.jdbc.Sql;
 
-import static org.mockito.BDDMockito.*;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.given;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Sql(scripts = "/init.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)

--- a/src/test/java/com/b4after/bntquestion/acceptance/AcceptanceTest.java
+++ b/src/test/java/com/b4after/bntquestion/acceptance/AcceptanceTest.java
@@ -1,10 +1,16 @@
 package com.b4after.bntquestion.acceptance;
 
+import com.b4after.bntquestion.domain.AnswerAudio;
+import com.b4after.bntquestion.service.AnswerAudioUploader;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
+import org.mockito.BDDMockito;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.context.jdbc.Sql;
+
+import static org.mockito.BDDMockito.*;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Sql(scripts = "/init.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
@@ -16,8 +22,14 @@ class AcceptanceTest {
 
     protected final Long memberId = 1L;
 
+    @MockBean
+    private AnswerAudioUploader answerAudioUploader;
+
     @BeforeEach
     void setUp() {
         RestAssured.port = port;
+
+        given(answerAudioUploader.upload(any()))
+                .willReturn(new AnswerAudio("mock-audio-file-object-key"));
     }
 }

--- a/src/test/java/com/b4after/bntquestion/acceptance/AnswerAcceptanceTest.java
+++ b/src/test/java/com/b4after/bntquestion/acceptance/AnswerAcceptanceTest.java
@@ -1,0 +1,36 @@
+package com.b4after.bntquestion.acceptance;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class AnswerAcceptanceTest extends AcceptanceTest {
+
+    @DisplayName("BNT 정답을 저장한다")
+    @Test
+    void saveAnswer() {
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .when()
+                .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
+                .multiPart("audio", "audio-file-name", "audio-byte".getBytes())
+                .formParam("memberId", memberId)
+                .formParam("questionId", 1L)
+                .post("/answers")
+                .then().log().all()
+                .extract();
+
+        // then
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value()),
+                () -> assertThat(response.headers().get("Location").getValue()).isEqualTo("/answers/1")
+        );
+    }
+}

--- a/src/test/java/com/b4after/bntquestion/acceptance/ResultAcceptanceTest.java
+++ b/src/test/java/com/b4after/bntquestion/acceptance/ResultAcceptanceTest.java
@@ -27,21 +27,21 @@ class ResultAcceptanceTest extends AcceptanceTest {
     @BeforeEach
     void executeBNT() {
         answerRepository.saveAll(List.of(
-                new Answer(1L, memberId, "audio.com", AnswerStatus.CORRECT),
-                new Answer(2L, memberId, "audio.com", AnswerStatus.CORRECT),
-                new Answer(3L, memberId, "audio.com", AnswerStatus.CORRECT),
-                new Answer(4L, memberId, "audio.com", AnswerStatus.CORRECT),
-                new Answer(5L, memberId, "audio.com", AnswerStatus.CORRECT),
-                new Answer(6L, memberId, "audio.com", AnswerStatus.CORRECT),
-                new Answer(7L, memberId, "audio.com", AnswerStatus.CORRECT),
-                new Answer(8L, memberId, "audio.com", AnswerStatus.CORRECT),
-                new Answer(9L, memberId, "audio.com", AnswerStatus.CORRECT),
-                new Answer(10L, memberId, "audio.com", AnswerStatus.INCORRECT),
-                new Answer(11L, memberId, "audio.com", AnswerStatus.INCORRECT),
-                new Answer(12L, memberId, "audio.com", AnswerStatus.INCORRECT),
-                new Answer(13L, memberId, "audio.com", AnswerStatus.INCORRECT),
-                new Answer(14L, memberId, "audio.com", AnswerStatus.INCORRECT),
-                new Answer(15L, memberId, "audio.com", AnswerStatus.INCORRECT)
+                new Answer(1L, memberId, "audio1.com", AnswerStatus.CORRECT),
+                new Answer(2L, memberId, "audio2.com", AnswerStatus.CORRECT),
+                new Answer(3L, memberId, "audio3.com", AnswerStatus.CORRECT),
+                new Answer(4L, memberId, "audio4.com", AnswerStatus.CORRECT),
+                new Answer(5L, memberId, "audio5.com", AnswerStatus.CORRECT),
+                new Answer(6L, memberId, "audio6.com", AnswerStatus.CORRECT),
+                new Answer(7L, memberId, "audio7.com", AnswerStatus.CORRECT),
+                new Answer(8L, memberId, "audio8.com", AnswerStatus.CORRECT),
+                new Answer(9L, memberId, "audio9.com", AnswerStatus.CORRECT),
+                new Answer(10L, memberId, "audio10.com", AnswerStatus.INCORRECT),
+                new Answer(11L, memberId, "audio11.com", AnswerStatus.INCORRECT),
+                new Answer(12L, memberId, "audio12.com", AnswerStatus.INCORRECT),
+                new Answer(13L, memberId, "audio13.com", AnswerStatus.INCORRECT),
+                new Answer(14L, memberId, "audio14.com", AnswerStatus.INCORRECT),
+                new Answer(15L, memberId, "audio15.com", AnswerStatus.INCORRECT)
         ));
     }
 

--- a/src/test/java/com/b4after/bntquestion/service/ResultServiceTest.java
+++ b/src/test/java/com/b4after/bntquestion/service/ResultServiceTest.java
@@ -9,6 +9,7 @@ import com.b4after.bntquestion.dto.BntResultResponse;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
@@ -26,6 +27,9 @@ class ResultServiceTest {
     @Autowired
     private EntityManager em;
 
+    @MockBean
+    private AnswerAudioUploader answerAudioUploader;
+
     @Test
     void getResultTest() {
         // given
@@ -36,8 +40,8 @@ class ResultServiceTest {
         em.persist(question1);
         em.persist(question2);
 
-        Answer answer1 = new Answer(1L, 1L, "Audio.com", AnswerStatus.CORRECT);
-        Answer answer2 = new Answer(2L, 1L, "Audio.com", AnswerStatus.INCORRECT);
+        Answer answer1 = new Answer(1L, 1L, "Audio1.com", AnswerStatus.CORRECT);
+        Answer answer2 = new Answer(2L, 1L, "Audio2.com", AnswerStatus.INCORRECT);
         em.persist(answer1);
         em.persist(answer2);
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,26 @@
+spring:
+  h2:
+    console:
+      enabled: true
+  jpa:
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+        hbm2ddl:
+          auto:
+            auto: create
+    open-in-view: false
+
+cloud:
+  aws:
+    region:
+      static: ap-northeast-2
+      auto: false
+    stack:
+      auto: false
+
+logging:
+  level:
+    org:
+      hibernate.sql: debug


### PR DESCRIPTION
@leehjhjhj 
## Key changes ⭐️
- /answers API 추가
  - `AnswerController`, `AnswerService`, `AnswerAudioUploader` 구현
- S3 의존성 추가
- Answer 스키마 변경
  - `audio_url` -> `audio_file_object_key`
<br>

## To Reviewers
- service 패키지 내부에선 aws s3 관련 의존성을 없애기 위해서 `AnswerAudioUploader`를 인터페이스로 만들어 사용하고, infrastructure 패키지 내부에서 인터페이스를 구현한 `S3AnswerAudioUploader`를 구현했어요. 서비스 계층에서 파일 저장소로 무엇을 사용하는지 숨기고 의존성을 역전시키기 위해 이런 방식으로 구현했습니다.
- 코드 양이 많지 않은데 그 외에 코드 가독성 관련하여 피드백 부탁드립니다!

## aws 환경변수 주입
application.yml에 s3 접근을 위한 access-key와 secret-key가 추가되었어요. 깃허브에 올릴 수 없기 때문에 환경변수 처리 해놓았습니다. RDS url과 같이 나중에 배포할 때 따로 주입하면 실행됩니다.

그런데 로컬에서 애플리케이션을 실행하려면 환경 변수를 넣어줘야 하기 때문에 따로 설정이 필요합니다.

1. edit configuration 열기
<img width="448" alt="image" src="https://user-images.githubusercontent.com/78652144/235663328-904f95a5-1293-4829-9195-e55945a9fe87.png">

2. modify options -> enviorment variables
<img width="748" alt="image" src="https://user-images.githubusercontent.com/78652144/235663673-406f4e1e-6efb-4a3c-8640-602519e8745a.png">
오른쪽에 문서 버튼 같은걸 클릭합니다.

3. 노션에 있는 access key, secret key 복붙하기
<img width="498" alt="image" src="https://user-images.githubusercontent.com/78652144/235663968-505ff39b-9004-4944-860a-d13155778f0a.png">

이렇게 세팅하고 나면 로컬에서 스프링을 실행할 수 있게 됩니다.